### PR TITLE
Adding URL to failed ci(s)

### DIFF
--- a/github/service.go
+++ b/github/service.go
@@ -25,7 +25,7 @@ func NewService(ctx context.Context, githubToken string) *Service {
 	}
 }
 
-func (s Service) WaitForChecksToSucceed(ctx context.Context, timeout time.Duration, owner string, repo string, sha string, checkNames []string) ([]string, error) {
+func (s Service) WaitForChecksToSucceed(ctx context.Context, timeout time.Duration, owner string, repo string, sha string, checkNames []string) ([]Status, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -33,6 +33,7 @@ func (s Service) WaitForChecksToSucceed(ctx context.Context, timeout time.Durati
 	statusTracker := newStatusTracker(checkNames)
 
 	for {
+		fmt.Println(statusTracker)
 		if err := ctx.Err(); err != nil {
 			return statusTracker.GetIncompleteChecks(), fmt.Errorf("timed out waiting for checks to start/complete: %w", err)
 		}
@@ -50,9 +51,14 @@ func (s Service) WaitForChecksToSucceed(ctx context.Context, timeout time.Durati
 		}
 
 		checksInProgress := statusTracker.GetIncompleteChecks()
+		var checksInProgressName []string
+		for _, status := range checksInProgress {
+			checksInProgressName = append(checksInProgressName, status.Name)
+		}
+
 		log.Printf(
 			"waiting for some checks to start and/or complete - %s. will check again in %d seconds\n",
-			strings.Join(checksInProgress, ", "),
+			strings.Join(checksInProgressName, ", "),
 			sleepTimeSeconds,
 		)
 		time.Sleep(time.Second * time.Duration(sleepTimeSeconds))
@@ -79,20 +85,26 @@ func (s Service) check(ctx context.Context, owner string, repo string, sha strin
 		return err
 	}
 
-	for name, currentRecordedStatus := range statusTracker {
-		if currentRecordedStatus != nil {
+	for name, status := range statusTracker {
+		if status.Finished {
 			continue
 		}
 
-		for _, status := range combinedStatus.Statuses {
-			if status.GetContext() == name {
-				switch status.GetState() {
+		for _, gitStatus := range combinedStatus.Statuses {
+			if gitStatus.GetContext() == name {
+				stat := statusTracker[name]
+				stat.Finished = true
+				stat.Url = gitStatus.GetTargetURL()
+				switch gitStatus.GetState() {
 				case "success":
-					statusTracker[name] = github.Bool(true)
+					stat.Succeeded = true
+					statusTracker[name] = stat
 				case "error":
-					statusTracker[name] = github.Bool(false)
+					stat.Succeeded = false
+					statusTracker[name] = stat
 				case "failure":
-					statusTracker[name] = github.Bool(false)
+					stat.Succeeded = false
+					statusTracker[name] = stat
 				}
 				break
 			}
@@ -102,43 +114,54 @@ func (s Service) check(ctx context.Context, owner string, repo string, sha strin
 	return nil
 }
 
-type statusTracker map[string]*bool
+type statusTracker map[string]Status
+
+type Status struct {
+	Name      string
+	Succeeded bool
+	Finished  bool
+	Url       string
+}
+
+func newStatus(name string) Status {
+	return Status{Name: name, Succeeded: false, Finished: false, Url: ""}
+}
+
+// type statusTracker struct {
+// 	statuses []Status
+// }
 
 func newStatusTracker(checkNames []string) statusTracker {
-	tracker := make(map[string]*bool)
+	tracker := make(statusTracker)
 	for _, name := range checkNames {
-		tracker[name] = nil
+		tracker[name] = newStatus(name)
 	}
 	return tracker
 }
 
-func (t statusTracker) GetFailedChecks() []string {
-	var failedChecks []string
-	for name, status := range t {
-		if status != nil && !*status {
-			failedChecks = append(failedChecks, name)
+func (t statusTracker) GetFailedChecks() []Status {
+	var failedChecks []Status
+	for _, status := range t {
+		if !status.Succeeded && status.Finished {
+			failedChecks = append(failedChecks, status)
 		}
 	}
 	return failedChecks
 }
 
-func (t statusTracker) GetIncompleteChecks() []string {
-	var incompleteChecks []string
-	for name, status := range t {
-		if status == nil {
-			incompleteChecks = append(incompleteChecks, name)
+func (t statusTracker) GetIncompleteChecks() []Status {
+	var incompleteChecks []Status
+	for _, status := range t {
+		if !status.Succeeded && !status.Finished {
+			incompleteChecks = append(incompleteChecks, status)
 		}
 	}
 	return incompleteChecks
 }
 
 func (t statusTracker) AllCompletedSuccessfully() bool {
-	for _, wasSuccessful := range t {
-		if wasSuccessful == nil {
-			return false
-		}
-
-		if !*wasSuccessful {
+	for _, status := range t {
+		if !status.Succeeded {
 			return false
 		}
 	}

--- a/github/service.go
+++ b/github/service.go
@@ -33,7 +33,6 @@ func (s Service) WaitForChecksToSucceed(ctx context.Context, timeout time.Durati
 	statusTracker := newStatusTracker(checkNames)
 
 	for {
-		fmt.Println(statusTracker)
 		if err := ctx.Err(); err != nil {
 			return statusTracker.GetIncompleteChecks(), fmt.Errorf("timed out waiting for checks to start/complete: %w", err)
 		}
@@ -124,12 +123,8 @@ type Status struct {
 }
 
 func newStatus(name string) Status {
-	return Status{Name: name, Succeeded: false, Finished: false, Url: ""}
+	return Status{Name: name}
 }
-
-// type statusTracker struct {
-// 	statuses []Status
-// }
 
 func newStatusTracker(checkNames []string) statusTracker {
 	tracker := make(statusTracker)

--- a/slack/service.go
+++ b/slack/service.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/tamj0rd2/pipeline-status-action/github"
 )
 
 func AlertThatStatusFailed(
@@ -14,9 +16,14 @@ func AlertThatStatusFailed(
 	webhookURL string,
 	commitURL, commitAuthor, commitMessage string,
 	errorMessage string,
-	failedStatuses []string,
+	failedStatuses []github.Status,
 ) error {
-	errorBody := fmt.Sprintf("*Error*: %s\n*Failed statuses*: %s", errorMessage, strings.Join(failedStatuses, ", "))
+	var failedStatusMsg []string
+	for _, status := range failedStatuses {
+		failedStatusMsg = append(failedStatusMsg, fmt.Sprintf("<%v|%s>", status.Url, status.Name))
+	}
+
+	errorBody := fmt.Sprintf("*Error*: %s\n*Failed statuses*: %s", errorMessage, strings.Join(failedStatusMsg, ", "))
 	commitDetails := fmt.Sprintf("*Commit author*: %s\n*Commit message*: %s", commitAuthor, commitMessage)
 
 	requestBody := fmt.Sprintf(`{


### PR DESCRIPTION
Adding the URL to failed ci checks. For that changed the body of the slack message and added a struct that takes the new field in consideration. Tested it locally with some manual examples and it looked like it was working fine

